### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopxl/pixel-examples
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/aquilax/go-perlin v1.1.0


### PR DESCRIPTION
With the existing, one gets the below when invoking `go run . ` when using Golang <= 1.20.
> $ go run .
go: errors parsing go.mod:
pixel-examples/go.mod:3: invalid go version '1.21.0': must match format 1.23

In my experience, the version in `go.mod` is always annotated as MAJOR.MINOR, without the patch/release so, while the current go.mod will work with Golang 1.21 and above, I think it's best to revise.